### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @paultrygs @KristianKjerstad @eoaksnes


### PR DESCRIPTION
Add CODEOWNERS file to enable require review from codeowners in main branch protection rule.